### PR TITLE
compatibility with mac

### DIFF
--- a/bin/kak-project
+++ b/bin/kak-project
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-session=$(printf %.7s $(printf %s "$PWD" | sha256sum))
+session=$(printf %.7s $(printf %s "$PWD" | (shasum -a 256)))
 
 kak -l | grep --quiet $session ||
   kak -d -s $session


### PR DESCRIPTION
`sha256sum` is not available on mac, but `shasum` available both on mac and linux.